### PR TITLE
Fix: Enables borderRadius to work with the component

### DIFF
--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -36,6 +36,8 @@
   if ((self = [super init])) {
     // Internal setup
     self.multipleTouchEnabled = NO;
+    // For borderRadius property to work (CALayer's cornerRadius).
+    self.layer.masksToBounds = YES;
     _eventDispatcher = eventDispatcher;
     _path = [UIBezierPath bezierPath];
 


### PR DESCRIPTION
Hi there,

I tried using the borderRadius style property and noticed it wasn't actually clipping the corners of the view. This change makes the borderRadius clipping work correctly.

Let me know if you want to chat about this or make changes, happy to help.