### PR TITLE
Roadmap: Allow clear to be called external to the component

### DIFF
--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -16,5 +16,6 @@
 - (void)setFillColor:(UIColor *)fillColor;
 - (void)setStrokeColor:(UIColor *)strokeColor;
 - (void)setClearButtonHidden:(BOOL)hidden;
+- (void)clearDrawing;
 
 @end

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -15,5 +15,6 @@
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispather NS_DESIGNATED_INITIALIZER;
 - (void)setFillColor:(UIColor *)fillColor;
 - (void)setStrokeColor:(UIColor *)strokeColor;
+- (void)setClearButtonHidden:(BOOL)hidden;
 
 @end

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -52,6 +52,11 @@
   [self drawBitmap];
 }
 
+- (void)setClearButtonHidden:(BOOL)hidden
+{
+  _clearButton.hidden = hidden;
+}
+
 
 #pragma mark - Subviews
 

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -39,7 +39,6 @@
     _eventDispatcher = eventDispatcher;
     _path = [UIBezierPath bezierPath];
 
-    // TODO: Find a way to get an functionnal external 'clear button'
     [self initClearButton];
   }
 

--- a/RNSketch/RNSketchManager.h
+++ b/RNSketch/RNSketchManager.h
@@ -7,11 +7,10 @@
 //
 
 #import "RCTViewManager.h"
+#import "RNSketch.h"
 
 @interface RNSketchManager : RCTViewManager
 
-@property (nonatomic, strong) UIColor *fillColor;
-@property (nonatomic, strong) UIColor *strokeColor;
-@property (nonatomic, assign) NSInteger strokeThickness;
+@property (strong) RNSketch *sketchView;
 
 @end;

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -19,7 +19,6 @@
 
 RCT_EXPORT_MODULE()
 
-
 #pragma mark - Properties
 
 
@@ -39,12 +38,23 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
 
 #pragma mark - Lifecycle
 
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    self.sketchView = nil;
+  }
+  
+  return self;
+}
 
 - (UIView *)view
 {
-  return [[RNSketch alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+  if (!self.sketchView) {
+    self.sketchView = [[RNSketch alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+  }
+  
+  return self.sketchView;
 }
-
 
 #pragma mark - Event types
 
@@ -82,6 +92,13 @@ RCT_EXPORT_METHOD(saveImage:(NSString *)encodedImage
     return reject(ERROR_FILE_CREATION, @"An error occured. Impossible to save the file.", nil);
   }
   resolve(@{@"path": fullPath});
+}
+
+RCT_EXPORT_METHOD(clear)
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self.sketchView clearDrawing];
+  });
 }
 
 @end

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -31,8 +31,11 @@ RCT_CUSTOM_VIEW_PROPERTY(strokeColor, UIColor, RNSketch)
 {
   [view setStrokeColor:json ? [RCTConvert UIColor:json] : [UIColor blackColor]];
 }
+RCT_CUSTOM_VIEW_PROPERTY(clearButtonHidden, BOOL, RNSketch)
+{
+  [view setClearButtonHidden:json ? [RCTConvert BOOL:json] : NO];
+}
 RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
-
 
 #pragma mark - Lifecycle
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -64,6 +64,10 @@ export default class Sketch extends React.Component {
     return SketchManager.saveImage(src);
   }
 
+  clear() {
+    return SketchManager.clear();
+  }
+
   render() {
     return (
       <RNSketch

--- a/index.ios.js
+++ b/index.ios.js
@@ -6,7 +6,7 @@ import {
   View,
 } from 'react-native';
 
-const { func, number, string } = React.PropTypes;
+const { func, number, string, bool } = React.PropTypes;
 
 const SketchManager = NativeModules.RNSketchManager || {};
 const BASE_64_CODE = 'data:image/jpg;base64,';
@@ -24,6 +24,7 @@ export default class Sketch extends React.Component {
     fillColor: string,
     onReset: func,
     onUpdate: func,
+    clearButtonHidden: bool,
     strokeColor: string,
     strokeThickness: number,
     style: View.propTypes.style,
@@ -33,6 +34,7 @@ export default class Sketch extends React.Component {
     fillColor: '#ffffff',
     onReset: () => {},
     onUpdate: () => {},
+    clearButtonHidden: false,
     strokeColor: '#000000',
     strokeThickness: 1,
     style: null,


### PR DESCRIPTION
We have a need to be able to clear the signature from outside of the component. I noticed this was on your roadmap so I figured I'd contribute the code back.

This PR does two things:
1. It exposes a prop that allows you to hide the in-built clear button. This prop defaults to false to preserve backwards compatibility.
2. It exposes a method called `clear()` which can be called from JS to clear the contents of the signature.

I also removed 3 properties from `RNSketchManager.h` because they weren't being used.

Let me know if any changes would be helpful here, I'm happy to amend as needed!