### PR TITLE
Handling placeholders in React code

### DIFF
--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -86,6 +86,13 @@
   _counter = 0;
   UITouch *touch = [touches anyObject];
   _points[0] = [touch locationInView:self];
+  
+  // Send event
+  NSDictionary *bodyEvent = @{
+                              @"target": self.reactTag,
+                              @"image": [self drawingToString],
+                              };
+  [_eventDispatcher sendInputEventWithName:@"topChange" body:bodyEvent];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event


### PR DESCRIPTION
We have a use case where we need a placeholder on top of the signature component which we then hide once the user starts drawing.

This change sends the change event on touch start as well as touch end so that anyone listening to the changes can react when users start drawing as well as when they finish.

I'm not sure this is generically helpful like this. I could be convinced very easily to make this a new event, but I couldn't get that to work for some reason. I kept getting JS errors about redefining events, so if there's a cleaner way to do this that I'm missing then I'm all ears.