### PR TITLE
Placeholder support

### DIFF
--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -86,6 +86,11 @@
   _counter = 0;
   UITouch *touch = [touches anyObject];
   _points[0] = [touch locationInView:self];
+  
+  NSDictionary *bodyEvent = @{
+                              @"target": self.reactTag,
+                              };
+  [_eventDispatcher sendInputEventWithName:@"onClearPlaceholder" body:bodyEvent];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -50,6 +50,7 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
 {
   return @[
            @"onReset",
+           @"onClearPlaceholder"
            ];
 }
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -24,6 +24,7 @@ export default class Sketch extends React.Component {
     fillColor: string,
     onReset: func,
     onUpdate: func,
+    onClearPlaceholder: func,
     strokeColor: string,
     strokeThickness: number,
     style: View.propTypes.style,
@@ -68,6 +69,7 @@ export default class Sketch extends React.Component {
         {...this.props}
         onChange={this.onUpdate}
         onReset={this.onReset}
+        onClearPlaceholder={this.onClearPlaceholder}
         style={[styles.base, this.props.style]}
       />
     );

--- a/index.ios.js
+++ b/index.ios.js
@@ -33,6 +33,7 @@ export default class Sketch extends React.Component {
   static defaultProps = {
     fillColor: '#ffffff',
     onReset: () => {},
+    onClearPlaceholder: () => {},
     onUpdate: () => {},
     strokeColor: '#000000',
     strokeThickness: 1,
@@ -42,12 +43,17 @@ export default class Sketch extends React.Component {
   constructor(props) {
     super(props);
     this.onReset = this.onReset.bind(this);
+    this.onClearPlaceholder = this.onClearPlaceholder.bind(this);
     this.onUpdate = this.onUpdate.bind(this);
   }
 
   onReset() {
     this.props.onUpdate(null);
     this.props.onReset();
+  }
+
+  onClearPlaceholder() {
+    this.props.onClearPlaceholder();
   }
 
   onUpdate(e) {


### PR DESCRIPTION
This adds an `onClearPlaceholder` event prop. It's actually when touches begin but it should signal to a consumer of the component that if they have a placeholder they should clear it. I tried using `onTouchStart` but that seemed to cause nasty conflicts with what React Native was doing so I renamed the event.