### PR TITLE
Update Sketch View From RN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.3.0] - 2017-01-19
+### Added
+- Added `clear` method to reset the drawing from outside (Thanks @blargity!).
+
+### Changed
+- Fix to make borderRadius property on the sketch view working (Thanks @blargity!).
+
 ## [v0.2.4] - 2016-06-06
 ### Changed
 - Corrected `PropTypes` import in index.ios.js - Removed from 'react-native' package...

--- a/README.md
+++ b/README.md
@@ -1,61 +1,53 @@
-# react-native-sketch
+# React Native Sketch
 
 [![Version](https://img.shields.io/npm/v/react-native-sketch.svg?style=flat-square)](http://npm.im/react-native-sketch)
 [![Downloads](https://img.shields.io/npm/dm/react-native-sketch.svg?style=flat-square)](http://npm.im/react-native-sketch)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-1dce73.svg?style=flat-square)](https://gitter.im/jgrancher/react-native-sketch)
 [![MIT License](https://img.shields.io/npm/l/react-native-sketch.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 
-*A react-native component for touch-based drawing.*
+*A React Native component for touch-based drawing.*
 
 ![Screenshots](https://cloud.githubusercontent.com/assets/5517450/15202227/ca865758-183b-11e6-8c4e-41080bc04538.jpg "Disclaimer: This is not my signature ;)")
 
 ## Getting started
 
-Install [rnpm](https://github.com/rnpm/rnpm) to make things easy:
+Install React Native Sketch:
 ```bash
-$ npm i -g rnpm
+$ npm install react-native-sketch
 ```
 
-Then, use rnpm to [install and link](https://github.com/rnpm/rnpm#running) this component to your project:
+Then, link it to your project:
 ```bash
-$ rnpm install react-native-sketch
+$ react-native link
 ```
+
+**Note**: If you are using an older version of React Native than `0.31`, you will need to install [rnpm](https://github.com/rnpm/rnpm) to link the module.
 
 ## Usage
 
 ```javascript
-import React, { Component } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React from 'react';
+import {
+  Button,
+  StyleSheet,
+  View,
+} from 'react-native';
 import Sketch from 'react-native-sketch';
 
 const styles = StyleSheet.create({
   container: {
-    padding: 20,
-  },
-  instructions: {
-    fontSize: 16,
-    marginBottom: 20,
-    textAlign: 'center',
+    flex: 1,
   },
   sketch: {
     height: 250, // Height needed; Default: 200px
-    marginBottom: 20,
-  },
-  button: {
-    alignItems: 'center',
-    backgroundColor: '#111111',
-    padding: 20,
-  },
-  buttonText: {
-    color: '#ffffff',
-    fontSize: 16,
   },
 });
 
-class Signature extends Component {
+class Signature extends React.Component {
 
   constructor(props) {
     super(props);
+    this.clear = this.clear.bind(this);
     this.onReset = this.onReset.bind(this);
     this.onSave = this.onSave.bind(this);
     this.onUpdate = this.onUpdate.bind(this);
@@ -64,6 +56,13 @@ class Signature extends Component {
   state = {
     encodedSignature: null,
   };
+
+  /**
+   * Clear / reset the drawing
+   */
+  clear() {
+    this.sketch.clear();
+  }
 
   /**
    * Do extra things after the sketch reset
@@ -94,9 +93,6 @@ class Signature extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.instructions}>
-          Use your finger on the screen to sign.
-        </Text>
         <Sketch
           fillColor="#f5f5f5"
           strokeColor="#111111"
@@ -106,13 +102,15 @@ class Signature extends Component {
           ref={(sketch) => { this.sketch = sketch; }}
           style={styles.sketch}
         />
-        <TouchableOpacity
+        <Button
+          onPress={this.clear}
+          title="Clear drawing"
+        />
+        <Button
           disabled={!this.state.encodedSignature}
-          style={styles.button}
           onPress={this.onSave}
-        >
-          <Text style={styles.buttonText}>Save</Text>
-        </TouchableOpacity>
+          title="Save drawing"
+        />
       </View>
     );
   }
@@ -122,16 +120,10 @@ class Signature extends Component {
 export default Signature;
 ```
 
-## Roadmap
-
-- [ ] Define a way for an external component to clear the current drawing.
-- [ ] Improve the documentation.
-- [ ] Make some tests.
-- [ ] Android support (help wanted ¯\\_(ツ)_/¯).
-
 ## Notes
 
-This component uses this [smooth freehand drawing technique](http://code.tutsplus.com/tutorials/smooth-freehand-drawing-on-ios--mobile-13164) under the hood.
+- The module is available *only on iOS* (for now), as I don't know Android development... But if you think you can help on that matter, please feel free to contact me!
+- The module uses this [smooth freehand drawing technique](http://code.tutsplus.com/tutorials/smooth-freehand-drawing-on-ios--mobile-13164) under the hood.
 
 ## Contributing
 
@@ -139,4 +131,4 @@ Feel free to contribute by sending a pull request or [creating an issue](https:/
 
 ## License
 
-MIT
+[MIT](https://github.com/jgrancher/react-native-sketch/tree/master/LICENSE)

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -15,5 +15,6 @@
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispather NS_DESIGNATED_INITIALIZER;
 - (void)setFillColor:(UIColor *)fillColor;
 - (void)setStrokeColor:(UIColor *)strokeColor;
+- (void)setImage:(NSURL *)image;
 
 @end

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -16,5 +16,6 @@
 - (void)setFillColor:(UIColor *)fillColor;
 - (void)setStrokeColor:(UIColor *)strokeColor;
 - (void)setClearButtonHidden:(BOOL)hidden;
+- (void)clearDrawing;
 
 @end

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -15,5 +15,6 @@
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispather NS_DESIGNATED_INITIALIZER;
 - (void)setFillColor:(UIColor *)fillColor;
 - (void)setStrokeColor:(UIColor *)strokeColor;
+- (void)setClearButtonHidden:(BOOL)hidden;
 
 @end

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -17,5 +17,6 @@
 - (void)setStrokeColor:(UIColor *)strokeColor;
 - (void)setClearButtonHidden:(BOOL)hidden;
 - (void)clearDrawing;
+- (void)setImage:(NSURL *)image;
 
 @end

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -36,6 +36,8 @@
   if ((self = [super init])) {
     // Internal setup
     self.multipleTouchEnabled = NO;
+    // For borderRadius property to work (CALayer's cornerRadius).
+    self.layer.masksToBounds = YES;
     _eventDispatcher = eventDispatcher;
     _path = [UIBezierPath bezierPath];
 

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -52,6 +52,11 @@
   [self drawBitmap];
 }
 
+- (void)setClearButtonHidden:(BOOL)hidden
+{
+  _clearButton.hidden = hidden;
+}
+
 
 #pragma mark - Subviews
 

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -39,7 +39,6 @@
     _eventDispatcher = eventDispatcher;
     _path = [UIBezierPath bezierPath];
 
-    // TODO: Find a way to get an functionnal external 'clear button'
     [self initClearButton];
   }
 

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -83,7 +83,6 @@
   [self addSubview:_clearButton];
 }
 
-
 #pragma mark - UIResponder methods
 
 
@@ -160,7 +159,7 @@
 
 - (void)drawBitmap
 {
-  UIGraphicsBeginImageContextWithOptions(self.bounds.size, YES, 0);
+  UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, UIViewContentModeScaleAspectFit);
 
   // If first time, paint background
   if (!_image) {
@@ -183,7 +182,7 @@
 
 - (NSString *)drawingToString
 {
-  return [UIImageJPEGRepresentation(_image, 1) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+  return [UIImagePNGRepresentation(_image) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
 
 
@@ -219,6 +218,14 @@
 - (void)setStrokeColor:(UIColor *)strokeColor
 {
   _strokeColor = strokeColor;
+}
+
+- (void)setImage:(NSURL *)image
+{
+  NSData *imageData = [NSData dataWithContentsOfURL:image];
+  _image = [UIImage imageWithData:imageData];
+  [self drawBitmap];
+  [self setNeedsDisplay];
 }
 
 - (void)setStrokeThickness:(NSInteger)strokeThickness

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -77,7 +77,6 @@
   [self addSubview:_clearButton];
 }
 
-
 #pragma mark - UIResponder methods
 
 
@@ -154,7 +153,7 @@
 
 - (void)drawBitmap
 {
-  UIGraphicsBeginImageContextWithOptions(self.bounds.size, YES, 0);
+  UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, UIViewContentModeScaleAspectFit);
 
   // If first time, paint background
   if (!_image) {
@@ -177,7 +176,7 @@
 
 - (NSString *)drawingToString
 {
-  return [UIImageJPEGRepresentation(_image, 1) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+  return [UIImagePNGRepresentation(_image) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
 
 
@@ -213,6 +212,14 @@
 - (void)setStrokeColor:(UIColor *)strokeColor
 {
   _strokeColor = strokeColor;
+}
+
+- (void)setImage:(NSURL *)image
+{
+  NSData *imageData = [NSData dataWithContentsOfURL:image];
+  _image = [UIImage imageWithData:imageData];
+  [self drawBitmap];
+  [self setNeedsDisplay];
 }
 
 - (void)setStrokeThickness:(NSInteger)strokeThickness

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -6,11 +6,11 @@
 //  Copyright © 2016 Jeremy Grancher. All rights reserved.
 //
 
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTView.h>
+#import <React/UIView+React.h>
 #import "RNSketch.h"
 #import "RNSketchManager.h"
-#import "RCTEventDispatcher.h"
-#import "RCTView.h"
-#import "UIView+React.h"
 
 @implementation RNSketch
 {

--- a/RNSketch/RNSketchManager.h
+++ b/RNSketch/RNSketchManager.h
@@ -7,11 +7,10 @@
 //
 
 #import "RCTViewManager.h"
+#import "RNSketch.h"
 
 @interface RNSketchManager : RCTViewManager
 
-@property (nonatomic, strong) UIColor *fillColor;
-@property (nonatomic, strong) UIColor *strokeColor;
-@property (nonatomic, assign) NSInteger strokeThickness;
+@property (strong) RNSketch *sketchView;
 
 @end;

--- a/RNSketch/RNSketchManager.h
+++ b/RNSketch/RNSketchManager.h
@@ -12,5 +12,9 @@
 @interface RNSketchManager : RCTViewManager
 
 @property (strong) RNSketch *sketchView;
+@property (nonatomic, strong) UIColor *fillColor;
+@property (nonatomic, strong) UIColor *strokeColor;
+@property (nonatomic, strong) NSURL *image;
+@property (nonatomic, assign) NSInteger strokeThickness;
 
 @end;

--- a/RNSketch/RNSketchManager.h
+++ b/RNSketch/RNSketchManager.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, strong) UIColor *fillColor;
 @property (nonatomic, strong) UIColor *strokeColor;
+@property (nonatomic, strong) NSURL *image;
 @property (nonatomic, assign) NSInteger strokeThickness;
 
 @end;

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -29,7 +29,11 @@ RCT_CUSTOM_VIEW_PROPERTY(fillColor, UIColor, RNSketch)
 }
 RCT_CUSTOM_VIEW_PROPERTY(strokeColor, UIColor, RNSketch)
 {
-  [view setStrokeColor:json ? [RCTConvert UIColor:json] : [UIColor blackColor]];
+  [view setStrokeColor:json ? [RCTConvert UIColor:json] : [UIColor clearColor]];
+}
+RCT_CUSTOM_VIEW_PROPERTY(image, NSURL, RNSketch)
+{
+    [view setImage:json ?[RCTConvert NSURL:json] : nil];
 }
 RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
 
@@ -53,9 +57,7 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
            ];
 }
 
-
 #pragma mark - Exported methods
-
 
 RCT_EXPORT_METHOD(saveImage:(NSString *)encodedImage
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -19,7 +19,6 @@
 
 RCT_EXPORT_MODULE()
 
-
 #pragma mark - Properties
 
 
@@ -39,12 +38,23 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
 
 #pragma mark - Lifecycle
 
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    self.sketchView = nil;
+  }
+  
+  return self;
+}
 
 - (UIView *)view
 {
-  return [[RNSketch alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+  if (!self.sketchView) {
+    self.sketchView = [[RNSketch alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+  }
+  
+  return self.sketchView;
 }
-
 
 #pragma mark - Event types
 
@@ -82,6 +92,13 @@ RCT_EXPORT_METHOD(saveImage:(NSString *)encodedImage
     return reject(ERROR_FILE_CREATION, @"An error occured. Impossible to save the file.", nil);
   }
   resolve(@{@"path": fullPath});
+}
+
+RCT_EXPORT_METHOD(clear)
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self.sketchView clearDrawing];
+  });
 }
 
 @end

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -6,11 +6,11 @@
 //  Copyright © 2016 Jeremy Grancher. All rights reserved.
 //
 
-#import "RNSketchManager.h"
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTView.h>
+#import <React/UIView+React.h>
 #import "RNSketch.h"
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import "RNSketchManager.h"
 
 #define ERROR_IMAGE_INVALID @"ERROR_IMAGE_INVALID"
 #define ERROR_FILE_CREATION @"ERROR_FILE_CREATION"

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -31,8 +31,11 @@ RCT_CUSTOM_VIEW_PROPERTY(strokeColor, UIColor, RNSketch)
 {
   [view setStrokeColor:json ? [RCTConvert UIColor:json] : [UIColor blackColor]];
 }
+RCT_CUSTOM_VIEW_PROPERTY(clearButtonHidden, BOOL, RNSketch)
+{
+  [view setClearButtonHidden:json ? [RCTConvert BOOL:json] : NO];
+}
 RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
-
 
 #pragma mark - Lifecycle
 

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -28,7 +28,11 @@ RCT_CUSTOM_VIEW_PROPERTY(fillColor, UIColor, RNSketch)
 }
 RCT_CUSTOM_VIEW_PROPERTY(strokeColor, UIColor, RNSketch)
 {
-  [view setStrokeColor:json ? [RCTConvert UIColor:json] : [UIColor blackColor]];
+  [view setStrokeColor:json ? [RCTConvert UIColor:json] : [UIColor clearColor]];
+}
+RCT_CUSTOM_VIEW_PROPERTY(image, NSURL, RNSketch)
+{
+    [view setImage:json ?[RCTConvert NSURL:json] : nil];
 }
 RCT_CUSTOM_VIEW_PROPERTY(clearButtonHidden, BOOL, RNSketch)
 {
@@ -66,9 +70,7 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger)
            ];
 }
 
-
 #pragma mark - Exported methods
-
 
 RCT_EXPORT_METHOD(saveImage:(NSString *)encodedImage
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/index.ios.js
+++ b/index.ios.js
@@ -27,6 +27,7 @@ export default class Sketch extends React.Component {
     clearButtonHidden: bool,
     strokeColor: string,
     strokeThickness: number,
+    image: string,
     style: View.propTypes.style,
   };
 
@@ -37,13 +38,16 @@ export default class Sketch extends React.Component {
     clearButtonHidden: false,
     strokeColor: '#000000',
     strokeThickness: 1,
-    style: null,
+    image: null,
+    style: null
   };
 
   constructor(props) {
     super(props);
     this.onReset = this.onReset.bind(this);
     this.onUpdate = this.onUpdate.bind(this);
+
+    this.state = {}
   }
 
   onReset() {
@@ -68,10 +72,22 @@ export default class Sketch extends React.Component {
     return SketchManager.clear();
   }
 
+  setImage(image) {
+    if (this.state.image == image) {
+      this.setState({
+          image: null
+      })
+    }
+    this.setState({
+        image
+    })
+  }
+
   render() {
     return (
       <RNSketch
         {...this.props}
+        image={this.state.image}
         onChange={this.onUpdate}
         onReset={this.onReset}
         style={[styles.base, this.props.style]}

--- a/index.ios.js
+++ b/index.ios.js
@@ -64,6 +64,10 @@ export default class Sketch extends React.Component {
     return SketchManager.saveImage(src);
   }
 
+  clear() {
+    return SketchManager.clear();
+  }
+
   render() {
     return (
       <RNSketch

--- a/index.ios.js
+++ b/index.ios.js
@@ -6,7 +6,7 @@ import {
   View,
 } from 'react-native';
 
-const { func, number, string } = React.PropTypes;
+const { func, number, string, bool } = React.PropTypes;
 
 const SketchManager = NativeModules.RNSketchManager || {};
 const BASE_64_CODE = 'data:image/jpg;base64,';
@@ -24,6 +24,7 @@ export default class Sketch extends React.Component {
     fillColor: string,
     onReset: func,
     onUpdate: func,
+    clearButtonHidden: bool,
     strokeColor: string,
     strokeThickness: number,
     style: View.propTypes.style,
@@ -33,6 +34,7 @@ export default class Sketch extends React.Component {
     fillColor: '#ffffff',
     onReset: () => {},
     onUpdate: () => {},
+    clearButtonHidden: false,
     strokeColor: '#000000',
     strokeThickness: 1,
     style: null,

--- a/index.ios.js
+++ b/index.ios.js
@@ -26,6 +26,7 @@ export default class Sketch extends React.Component {
     onUpdate: func,
     strokeColor: string,
     strokeThickness: number,
+    image: string,
     style: View.propTypes.style,
   };
 
@@ -35,13 +36,16 @@ export default class Sketch extends React.Component {
     onUpdate: () => {},
     strokeColor: '#000000',
     strokeThickness: 1,
-    style: null,
+    image: null,
+    style: null
   };
 
   constructor(props) {
     super(props);
     this.onReset = this.onReset.bind(this);
     this.onUpdate = this.onUpdate.bind(this);
+
+    this.state = {}
   }
 
   onReset() {
@@ -62,10 +66,22 @@ export default class Sketch extends React.Component {
     return SketchManager.saveImage(src);
   }
 
+  setImage(image) {
+    if (this.state.image == image) {
+      this.setState({
+          image: null
+      })
+    }
+    this.setState({
+        image
+    })
+  }
+
   render() {
     return (
       <RNSketch
         {...this.props}
+        image={this.state.image}
         onChange={this.onUpdate}
         onReset={this.onReset}
         style={[styles.base, this.props.style]}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sketch",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "A react-native component for touch-based drawing",
   "main": "index.ios.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-native": "^0.24.1"
   },
   "scripts": {
-    "postversion": "git push && git push --tags",
+    "postversion": "git push --follow-tags",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
- Added an image property that can be used by React Native to force an update to the native view with the new function `setImage(image)` where image is a base64 encoded string. 
- Allowed for transparent background, and switched the default background from blackColor to clearColor.

Similar to what @stantoncbradley did in response to #6, I wanted to be able to draw on top of an image, and I also wanted to add the ability to undo lines that were drawn. I am working in RN ~0.40, so I opened this up against the react-native-0.40 branch.
![sketch](https://cloud.githubusercontent.com/assets/5564314/25009775/79ac11d8-202d-11e7-8d31-8824feea4b7a.gif)


