### PR TITLE
Initial Image and/or Custom Image Data Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Here are the `props` of the the component:
 | ---- | ---- | ------------- | ---- |
 | `fillColor` | `String` | `null` | The color of the sketch background. Default to null to keep it transparent! *Note: This is different from the `style.backgroundColor` property, as the former will be seen in your exported drawing image, whereas the latter is only used to style the view.* |
 | `imageType` | `String` | `png` | The type of image to export. Can be `png` or `jpg`. Default to `png` to get transparency out of the box. |
+| `imageData` | `String` | `null` | PNG/JPEG image intepretation encoded with base64 to render on the drawing canvas. |
 | `onChange` | `Function` | `() => {}` | Callback function triggered after every change on the drawing. The function takes one argument: the actual base64 representation of your drawing.|
 | `onClear` | `Function` | `() => {}` | Callback function triggered after a `clear` has been triggered. |
 | `strokeColor` | `String` | `'#000000'` | The stroke color you want to draw with. |
@@ -79,6 +80,12 @@ The component also has some instance methods:
 | ---- | ----------- | ------- |
 | `clear()` | `Promise` | Clear the drawing. This method is a Promise mostly to be consistent with `save()`, but you could simply type: `this.sketch.clear();` |
 | `save()` | `Promise` | Save the drawing to an image, using the defined props as settings (`imageType`, `fillColor`, etc...). The Promise resolves with an object containing the `path` property of that image. Ex: `this.sketch.save().then(image => console.log(image.path));` |
+
+Here are a few static helper functions for the component:
+
+| Name | Return type | Comment |
+| ---- | ----------- | ------- |
+| `getImageDataFromFilePath` | `Promise` | Reads a JPEG or PNG file into base64 image data that can be rendered using the `imageData` prop. |
 
 ## Examples
 

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -29,5 +29,6 @@
 @property (nonatomic, strong) NSString *imageType;
 @property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, assign) NSInteger strokeThickness;
+@property (nonatomic, strong) NSURL *imageURL;
 
 @end

--- a/RNSketch/RNSketch.h
+++ b/RNSketch/RNSketch.h
@@ -29,6 +29,6 @@
 @property (nonatomic, strong) NSString *imageType;
 @property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, assign) NSInteger strokeThickness;
-@property (nonatomic, strong) NSURL *imageURL;
+@property (nonatomic, strong) NSURL *imageData;
 
 @end

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -116,7 +116,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)drawBitmap
 {
-  UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, 0);
+  UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, UIViewContentModeScaleAspectFit);
 
   // Paint background if fillColor property provided
   if (!_image && _fillColor) {
@@ -183,9 +183,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _strokeColor = strokeColor;
 }
 
-- (void)setImageURL:(NSURL *)imageURL
+- (void)setImageData:(NSURL *)imageURLData
 {
-  NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
+  NSData *imageData = [NSData dataWithContentsOfURL:imageURLData];
   _image = [UIImage imageWithData:imageData];
   [self drawBitmap];
   [self setNeedsDisplay];

--- a/RNSketch/RNSketch.m
+++ b/RNSketch/RNSketch.m
@@ -183,6 +183,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _strokeColor = strokeColor;
 }
 
+- (void)setImageURL:(NSURL *)imageURL
+{
+  NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
+  _image = [UIImage imageWithData:imageData];
+  [self drawBitmap];
+  [self setNeedsDisplay];
+}
+
 - (void)setStrokeThickness:(NSInteger)strokeThickness
 {
   _path.lineWidth = strokeThickness;

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -36,6 +36,7 @@ RCT_EXPORT_VIEW_PROPERTY(fillColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(imageType, NSString);
 RCT_EXPORT_VIEW_PROPERTY(strokeColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger);
+RCT_EXPORT_VIEW_PROPERTY(imageURL, NSURL);
 
 #pragma mark - Lifecycle
 
@@ -54,6 +55,7 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger);
     self.sketchView = [[RNSketch alloc] initWithFrame:CGRectZero];
   }
 
+<<<<<<< HEAD
   return self.sketchView;
 }
 
@@ -61,6 +63,11 @@ RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger);
 
 RCT_EXPORT_METHOD(saveDrawing:(NSString *)encodedImage
                   ofType:(NSString *)imageType
+=======
+#pragma mark - Exported methods
+
+RCT_EXPORT_METHOD(saveImage:(NSString *)encodedImage
+>>>>>>> 4b1b0e6... Added image property that can be used by React Native to force an update to the native view
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {

--- a/RNSketch/RNSketchManager.m
+++ b/RNSketch/RNSketchManager.m
@@ -36,7 +36,7 @@ RCT_EXPORT_VIEW_PROPERTY(fillColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(imageType, NSString);
 RCT_EXPORT_VIEW_PROPERTY(strokeColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(strokeThickness, NSInteger);
-RCT_EXPORT_VIEW_PROPERTY(imageURL, NSURL);
+RCT_EXPORT_VIEW_PROPERTY(imageData, NSURL);
 
 #pragma mark - Lifecycle
 
@@ -55,7 +55,6 @@ RCT_EXPORT_VIEW_PROPERTY(imageURL, NSURL);
     self.sketchView = [[RNSketch alloc] initWithFrame:CGRectZero];
   }
 
-<<<<<<< HEAD
   return self.sketchView;
 }
 
@@ -63,11 +62,6 @@ RCT_EXPORT_VIEW_PROPERTY(imageURL, NSURL);
 
 RCT_EXPORT_METHOD(saveDrawing:(NSString *)encodedImage
                   ofType:(NSString *)imageType
-=======
-#pragma mark - Exported methods
-
-RCT_EXPORT_METHOD(saveImage:(NSString *)encodedImage
->>>>>>> 4b1b0e6... Added image property that can be used by React Native to force an update to the native view
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {

--- a/index.ios.js
+++ b/index.ios.js
@@ -12,6 +12,7 @@ export default class Sketch extends React.Component {
     onClear: PropTypes.func,
     strokeColor: PropTypes.string,
     strokeThickness: PropTypes.number,
+    imagePath: PropTypes.string,
     style: View.propTypes.style,
   };
 
@@ -22,7 +23,8 @@ export default class Sketch extends React.Component {
     onClear: () => {},
     strokeColor: '#000000',
     strokeThickness: 1,
-    style: null,
+    image: null,
+    style: null
   };
 
   constructor(props) {
@@ -67,6 +69,7 @@ export default class Sketch extends React.Component {
         strokeColor={strokeColor}
         strokeThickness={strokeThickness}
         style={[this.style, this.props.style]}
+        imageURL={this.props.imagePath}
       />
     );
   }

--- a/index.ios.js
+++ b/index.ios.js
@@ -23,7 +23,7 @@ export default class Sketch extends React.Component {
     onClear: () => {},
     strokeColor: '#000000',
     strokeThickness: 1,
-    image: null,
+    imageData: null,
     style: null
   };
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { NativeModules, requireNativeComponent, View, ViewPropTypes } from 'react-native';
+import RNFS from 'react-native-fs';
 
 const SketchManager = NativeModules.RNSketchManager || {};
 
@@ -29,6 +30,25 @@ export default class Sketch extends React.Component {
     imageData: null,
     style: null
   };
+
+  static getImageDataFromFilePath(filePath) {
+    const formats = {
+      "jpg": "image/jpg",
+      "jpeg": "image/jpg",
+      "png": "image/png"
+    }
+    const fileExtension = filePath.split('.').pop();
+    const format = formats[fileExtension];
+
+    if (!format) {
+      throw new Error(`Unable to parse file extension .${fileExtension}`)
+    }
+
+    return RNFS.readFile(filePath.path, 'base64')
+      .then((base64) => {
+          return `data:${format};base64,${base64}`;
+      })
+  }
 
   constructor(props) {
     super(props);

--- a/index.ios.js
+++ b/index.ios.js
@@ -12,7 +12,7 @@ export default class Sketch extends React.Component {
     onClear: PropTypes.func,
     strokeColor: PropTypes.string,
     strokeThickness: PropTypes.number,
-    imagePath: PropTypes.string,
+    imageData: PropTypes.string,
     style: View.propTypes.style,
   };
 
@@ -35,11 +35,17 @@ export default class Sketch extends React.Component {
       flex: 1,
       backgroundColor: 'transparent',
     };
+
+    this.state = {
+      imageData: props.imageData
+    }
   }
 
-  state = {
-    imageData: null,
-  };
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+        imageData: nextProps.imageData
+    })
+  }
 
   onChange = (event) => {
     const { imageData } = event.nativeEvent;
@@ -69,7 +75,7 @@ export default class Sketch extends React.Component {
         strokeColor={strokeColor}
         strokeThickness={strokeThickness}
         style={[this.style, this.props.style]}
-        imageURL={this.props.imagePath}
+        imageData={this.state.imageData}
       />
     );
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A react-native component for touch-based drawing",
   "main": "index.ios.js",
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-native-fs": "^2.10.14"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
This is a rebuild of my coworker @gensc004's work to allow initial images to the Sketchpad. I have more past experience with ObjC code so I worked on upgrading it to work inline with the change that happened in this library since #27 was opened.

The implementation I built here is a new prop, `imageData` that is passed into the native component.  Here's what happens:

1. `<Sketch` is passed `imageData` as a prop at first render.
1. Prop is copied to `state` of the JS component, and sent to the native component.
1. *(later):* Native component calls `onChange()` when a line is drawn.
1. JS component updates `state` and reapplies `imageData` to the native component <- **this causes double rendering of the line...once immediately after the line is drawn, and again once the JS code "accepts" the line.**
1. *(opt):* At any time, a new `imageData` value passed to `<Sketch` will overwrite the current value rendered in native code. If the parent component calls `setState()` within the `onChange()` function's callback, the change will be deduplicated by the React reconciler and only the parent component's value will be applied.

For me, the double rendering resolves an issue where the JS state is out-of-sync with the ObjC state for this component. Ideally, we would only need to render once...but the solution to this could be in a few different ways...I would vote to either leave the double rendering as there's minimal performance impact, or have the end-of-line-drawn not trigger the render, and rely on the JS state for accurate `imageData` information.

### Remaining Tasks

- [ ] Discuss & agree on double-rendering ObjC code
- [ ] Add documentation for the new property