### PR TITLE
Proposed fix for #37

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -56,7 +56,11 @@ export default class Sketch extends React.Component {
 
   clear = () => SketchManager.clearDrawing();
 
-  save = () => SketchManager.saveDrawing(this.state.imageData, this.props.imageType);
+  save = () => {
+    if (!this.state.imageData) return Promise.reject('No image provided!');
+
+    return SketchManager.saveDrawing(this.state.imageData, this.props.imageType);
+  };
 
   render() {
     const { fillColor, strokeColor, strokeThickness, ...props } = this.props;


### PR DESCRIPTION
Rejects the `save()` promise if `this.state.imageData` is null. Should prevent the module from crashing when trying to save without drawing anything first.